### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+ci/
+.editorconfig
+eslint*
+CONTRIBUTING.md
+screwdriver.yaml
+test/
+features/

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const clone = require('clone');
 const joi = require('joi');
 
@@ -15,7 +16,7 @@ const joi = require('joi');
  */
 function generateMatrixHelper(options, currentCombination,
                                 keysToIterate, keyIndexer, permutations) {
-    if (keysToIterate.every((optionKey) => currentCombination[optionKey])) {
+    if (keysToIterate.every(optionKey => currentCombination[optionKey])) {
         permutations.push(currentCombination);
 
         return;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 
 describe('index test', () => {


### PR DESCRIPTION
So we don't bundle extra files in our packages

Related to https://github.com/screwdriver-cd/screwdriver/issues/324
