### PR TITLE
fix: Update joi to version 13

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const joi = require('joi');
   * @return {Array}                         List of permutations of the environment
  */
 function generateMatrixHelper(options, currentCombination,
-                                keysToIterate, keyIndexer, permutations) {
+    keysToIterate, keyIndexer, permutations) {
     if (keysToIterate.every(optionKey => currentCombination[optionKey])) {
         permutations.push(currentCombination);
 
@@ -31,7 +31,7 @@ function generateMatrixHelper(options, currentCombination,
         nextCombination[keyToAdd] = value;
 
         return generateMatrixHelper(options, nextCombination,
-          keysToIterate, nextKeyIndexer, permutations);
+            keysToIterate, nextKeyIndexer, permutations);
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
-    "jenkins-mocha": "^3.0.4"
+    "eslint": "^4.3.0",
+    "eslint-config-screwdriver": "^3.0.0",
+    "jenkins-mocha": "^4.0.0"
   },
   "dependencies": {
     "clone": "^1.0.2",
-    "joi": "^10.0.5"
+    "joi": "^13.0.0"
   }
 }


### PR DESCRIPTION
Turns out we are still using this package in [config-parser](https://github.com/screwdriver-cd/config-parser/blob/master/package.json#L54)
Related to https://github.com/screwdriver-cd/keymbinatorial/pull/11