### PR TITLE
feat: Update package.json for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymbinatorial.git"
+    "url": "git+https://github.com/screwdriver-cd/keymbinatorial.git"
   },
   "homepage": "https://github.com/screwdriver-cd/keymbinatorial",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",


### PR DESCRIPTION
## Context

Need to fix repository URL.

## Objective

This PR fixes semantic release repo URL.

## References

Related to https://github.com/screwdriver-cd/keymbinatorial/pull/20

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
